### PR TITLE
Login and Register components now reset the state error to null!

### DIFF
--- a/wedding-planner/src/actions/index.js
+++ b/wedding-planner/src/actions/index.js
@@ -202,3 +202,11 @@ export const putEvent = event => dispatch => {
             } else { dispatch({ type: PUT_EVENT_FAILURE, payload: `${err}`}); }
         })
 }
+
+//================================NOERRORS================================//
+export const NO_ERROR = "NO_ERROR";
+export const noError = () => {
+    return {
+        type: NO_ERROR,
+    }
+}

--- a/wedding-planner/src/components/login/Login.js
+++ b/wedding-planner/src/components/login/Login.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { login } from "../../actions";
+import { login, noError } from "../../actions";
 import wg_logo from "../../utils/wg_logo.png"
 import Loader from "react-loaders";
 import "./Login.scss";
@@ -46,6 +46,11 @@ class Login extends React.Component {
         );
     }
 
+
+    componentDidMount() {
+        this.props.noError();
+    }
+
     handleChanges = e => {
         e.preventDefault();
         this.setState({
@@ -77,4 +82,4 @@ const mapStateToProps = ({ loggingIn, error }) => {
     };
 }
 
-export default connect(mapStateToProps, {login} )(Login);
+export default connect(mapStateToProps, { login, noError } )(Login);

--- a/wedding-planner/src/components/login/Login.scss
+++ b/wedding-planner/src/components/login/Login.scss
@@ -114,12 +114,7 @@ $primary-color: #0A235C;
         p {
             margin: 0;
             padding: 1%;
-            color: lightblue;
             font-weight: bold;
-            &:hover {
-                cursor: pointer;
-                color: #4664F5;
-            }
         }
     }
 }

--- a/wedding-planner/src/components/register/Register.js
+++ b/wedding-planner/src/components/register/Register.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { register } from "../../actions";
+import { register, noError } from "../../actions";
 import wg_logo from "../../utils/wg_logo.png"
 import Loader from "react-loaders";
 import "./Register.scss";
@@ -136,6 +136,10 @@ class Register extends React.Component {
         );
     }
 
+    componentDidMount() {
+        this.props.noError();
+    }
+
     handleChanges = e => {
         e.preventDefault();
         this.setState({
@@ -169,4 +173,4 @@ const mapStateToProps = ({ loggingIn, error }) => {
     };
 }
 
-export default connect(mapStateToProps, {register} )(Register);
+export default connect(mapStateToProps, { register, noError } )(Register);

--- a/wedding-planner/src/components/register/Register.scss
+++ b/wedding-planner/src/components/register/Register.scss
@@ -123,12 +123,7 @@ $primary-color: #0A235C;
         p {
             margin: 0;
             padding: 1%;
-            color: lightblue;
             font-weight: bold;
-            &:hover {
-                cursor: pointer;
-                color: #4664F5;
-            }
         }
     }
 }

--- a/wedding-planner/src/reducers/index.js
+++ b/wedding-planner/src/reducers/index.js
@@ -8,6 +8,7 @@ import {
     POST_EVENT_START, POST_EVENT_SUCCESS, POST_EVENT_FAILURE,
     PUT_EVENT_START, PUT_EVENT_SUCCESS, PUT_EVENT_FAILURE,
     DELETE_EVENT_START, DELETE_EVENT_SUCCESS, DELETE_EVENT_FAILURE,
+    NO_ERROR,
 } from '../actions';
 
 
@@ -235,6 +236,14 @@ export const reducer = (state = initialState, action) => {
                 ...state,
                 deletingEvent: false,
                 error: action.payload
+            }
+
+        //================================DELETEEVENT================================//
+
+        case NO_ERROR:
+            return {
+                ...state,
+                error: null,
             }
 
             


### PR DESCRIPTION
Previously, if there was an error on a page and then the user went to the login or register components, the unrelated error would appear inside the log in/register box. This fixes that.

And, the error no longer turns blue when you hover over it.